### PR TITLE
Add the ability to set the name, description and excluded characters in a secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Resources:
     Properties:
       Parameters:
         KmsKeyModule: !GetAtt 'Key.Outputs.StackName' # optional
+        Name: 'my-secret-name' #optional
+        Description: 'A secret description' #optional
+        CharactersToExclude: '!@#$%^&*()' # optional
       TemplateURL: './node_modules/@cfn-modules/secret/module.yml'
 ```
 
@@ -55,6 +58,27 @@ none
       <td>KmsKeyModule</td>
       <td>Stack name of <a href="https://www.npmjs.com/package/@cfn-modules/kms-key">kms-key module</a></td>
       <td></td>
+      <td>no</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Name</td>
+      <td>The name to give the secret. This is the name shown in the AWS Console</a></td>
+      <td></td>
+      <td>no</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Description</td>
+      <td>The description to give the secret. This is the description shown in the AWS Console</a></td>
+      <td></td>
+      <td>no</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>CharactersToExclude</td>
+      <td>When generating the initial value these characters will not be used.</a></td>
+      <td>'"@/\'</td>
       <td>no</td>
       <td></td>
     </tr>

--- a/module.yml
+++ b/module.yml
@@ -18,16 +18,32 @@ Parameters:
     Description: 'Optional but recommended stack name of kms-key module.'
     Type: String
     Default: ''
+  Name:
+    Description: 'Optional name of the secret.'
+    Type: String
+    Default: ''
+  Description:
+    Description: 'Optional description of the secret.'
+    Type: String
+    Default: ''
+  CharactersToExclude:
+    Description: 'Optional characters not to be used when generating the initial value.'
+    Type: String
+    Default: '"@/\'
 Conditions:
   HasKmsKeyModule: !Not [!Equals [!Ref KmsKeyModule, '']]
+  HasName: !Not [!Equals [!Ref Name, '']]
+  HasDescription: !Not [!Equals [!Ref Description, '']]
 Resources:
   Secret:
     Type: 'AWS::SecretsManager::Secret'
     Properties:
       KmsKeyId: !If [HasKmsKeyModule, {'Fn::ImportValue': !Sub '${KmsKeyModule}-Arn'}, !Ref 'AWS::NoValue']
+      Name: !If [HasName, !Ref 'Name', !Ref 'AWS::NoValue']
+      Description: !If [HasDescription, !Ref 'Description', !Ref 'AWS::NoValue']
       GenerateSecretString:
         PasswordLength: 30
-        ExcludeCharacters: '"@/\'
+        ExcludeCharacters: !Ref 'CharactersToExclude'
 Outputs:
   ModuleId:
     Value: 'secret'

--- a/test/test.js
+++ b/test/test.js
@@ -21,3 +21,33 @@ test.serial('with-kms', async t => {
     t.pass(); 
   }
 });
+test.serial('with-name', async t => {
+  const stackName = cfntest.stackName();
+  try {
+    t.log(await cfntest.createStack(`${__dirname}/with-name.yml`, stackName, {}));
+    // what could we test here?
+  } finally {
+    t.log(await cfntest.deleteStack(stackName));
+    t.pass(); 
+  }
+});
+test.serial('with-description', async t => {
+  const stackName = cfntest.stackName();
+  try {
+    t.log(await cfntest.createStack(`${__dirname}/with-description.yml`, stackName, {}));
+    // what could we test here?
+  } finally {
+    t.log(await cfntest.deleteStack(stackName));
+    t.pass(); 
+  }
+});
+test.serial('with-excluded-chars', async t => {
+  const stackName = cfntest.stackName();
+  try {
+    t.log(await cfntest.createStack(`${__dirname}/with-excluded-chars.yml`, stackName, {}));
+    // what could we test here?
+  } finally {
+    t.log(await cfntest.deleteStack(stackName));
+    t.pass(); 
+  }
+});

--- a/test/with-description.yml
+++ b/test/with-description.yml
@@ -1,0 +1,10 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'cfn-modules test'
+Resources:
+  Secret:
+    Type: 'AWS::CloudFormation::Stack'
+    Properties:
+      Parameters:
+        Description: 'A top secret secret.'
+      TemplateURL: './node_modules/@cfn-modules/secret/module.yml'

--- a/test/with-excluded-chars.yml
+++ b/test/with-excluded-chars.yml
@@ -1,0 +1,10 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'cfn-modules test'
+Resources:
+  Secret:
+    Type: 'AWS::CloudFormation::Stack'
+    Properties:
+      Parameters:
+        CharactersToExclude: '!@#$%^&*()'
+      TemplateURL: './node_modules/@cfn-modules/secret/module.yml'

--- a/test/with-name.yml
+++ b/test/with-name.yml
@@ -1,0 +1,10 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'cfn-modules test'
+Resources:
+  Secret:
+    Type: 'AWS::CloudFormation::Stack'
+    Properties:
+      Parameters:
+        Name: 'TopSecret'
+      TemplateURL: './node_modules/@cfn-modules/secret/module.yml'


### PR DESCRIPTION
I think it would be useful to be able to name secrets and have some control over the characters for the initial values. I also updated the default characters to exclude to make this module work better with the rds-aurora-serverless module. The MySql master password cannot contain quotes or semicolons.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
